### PR TITLE
Talk 18  feat/chat/view join Feat: 채팅방 인원조회 기능 추가

### DIFF
--- a/apis/chatAPI.ts
+++ b/apis/chatAPI.ts
@@ -1,0 +1,16 @@
+import Jwtinterceptors from './Jwtinterceptors';
+
+const { instance } = Jwtinterceptors();
+
+const chatAPI = {
+  // 특정 채팅방 정보조회
+  getChatInfo(chatId: string) {
+    return instance.get(`/chat/only?chatId=${chatId}`);
+  },
+  // 특정 유저 조회
+  getUserInfo(userId: string) {
+    return instance.get(`/chat/user?userId=${userId}`);
+  },
+};
+
+export default chatAPI;

--- a/components/chat/Chat.module.scss
+++ b/components/chat/Chat.module.scss
@@ -83,13 +83,31 @@
     padding: 1rem;
     border-bottom: 0.1rem solid $brand-pink;
   }
+  .userDiv {
+    max-height: 20rem; /* 목록의 최대 높이 */
+    overflow-y: auto; /* 내용이 넘칠 경우 스크롤을 생성 */
+  }
   li {
     padding: 0.8rem 0;
-
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
     cursor: pointer;
 
     &:hover {
       background-color: $light-gray; // 항목에 호버 시 배경색 변경
+    }
+    .profileImage {
+      width: 3.5rem;
+      height: 3.5rem;
+      border-radius: 50%;
+      margin-right: 0.5rem;
+    }
+    .username {
+      font-size: $font-size-s;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
   }
 

--- a/components/chat/header.tsx
+++ b/components/chat/header.tsx
@@ -2,15 +2,17 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { HiArrowLongLeft } from 'react-icons/hi2';
 import { IoMdMenu } from 'react-icons/io';
+import { ChatUser } from '@/@types/types';
 import styles from './Chat.module.scss';
 import Jwtinterceptors from '../../apis/Jwtinterceptors';
 
 interface Props {
   chatId: string;
   name: string;
+  users: ChatUser[];
 }
 
-export default function ChatroomHeader({ chatId, name }: Props) {
+export default function ChatroomHeader({ chatId, name, users }: Props) {
   const router = useRouter();
 
   const { instance } = Jwtinterceptors();
@@ -65,11 +67,20 @@ export default function ChatroomHeader({ chatId, name }: Props) {
           <div className={styles.dropdownMenu}>
             <ul>
               <div>
-                <p>현재 인원 수</p>
-                <h6>OO명</h6>
+                <p>현재 채팅인원 수</p>
+                <h6>{users.length}명</h6>
               </div>
-              <div>
-                <li>참여자 1</li>
+              <div className={styles.userDiv}>
+                {users.map(user => (
+                  <li key={user.id}>
+                    <img
+                      src={user.picture}
+                      className={styles.profileImage}
+                      alt="User"
+                    />
+                    <span className={styles.username}>{user.username}</span>
+                  </li>
+                ))}
               </div>
             </ul>
             <button

--- a/components/chat/otherchat.tsx
+++ b/components/chat/otherchat.tsx
@@ -10,7 +10,6 @@ interface GetUserNameResponseBody {
 }
 
 function OtherMessage({ msg }: { msg: Message }) {
-
   const today = new Date();
   const isToday = today.toISOString().split('T')[0];
   const dateString = todayDate(msg.createdAt);
@@ -24,18 +23,19 @@ function OtherMessage({ msg }: { msg: Message }) {
   useEffect(() => {
     const getUserName = async () => {
       try {
-        const response = await instance.get<GetUserNameResponseBody>(`/user?userId=${msg.userId}`);
+        const response = await instance.get<GetUserNameResponseBody>(
+          `/user?userId=${msg.userId}`,
+        );
         setUserName(response.data.user.name);
         setUserPicture(response.data.user.picture);
       } catch (error) {
         console.error('Failed to fetch user name:', error);
       }
     };
-  
+
     getUserName();
   }, [instance, msg.userId]); // 의존성 배열에는 getUserName 함수가 사용하는 모든 변수를 포함시켜야 합니다.
-  
-  
+
   return (
     <div className={styles.otherFlex}>
       <div className={styles.userInfo}>

--- a/pages/chat/[chatId].tsx
+++ b/pages/chat/[chatId].tsx
@@ -7,7 +7,7 @@ import OtherChat from '@/components/chat/otherchat';
 import EntryNotice from '@/components/chat/entryNotice';
 import ExitNotice from '@/components/chat/exitNotice';
 import ChatAlert from '@/components/chat/chatAlert';
-import { JoinersData, LeaverData, Message } from '@/@types/types';
+import { Chat, JoinersData, LeaverData, Message } from '@/@types/types';
 import { useRouter } from 'next/router';
 import { userIdState } from '@/recoil/atoms/userIdState';
 import { getStorage } from '@/utils/loginStorage';
@@ -15,12 +15,30 @@ import { getStorage } from '@/utils/loginStorage';
 import { CLIENT_URL } from '../../apis/constant';
 import styles2 from '../../components/chat/Chat.module.scss';
 import ChatroomHeader from '../../components/chat/header';
+import chatAPI from '../../apis/chatAPI';
 
-export default function Chat() {
+export default function Chatting() {
   const router = useRouter();
-  const { chatId, name } = router.query;
+  const { chatId } = router.query;
 
-  const [, setIsConnected] = useState(false);
+  const [chatData, setChatData] = useState<Chat | null>();
+
+  useEffect(() => {
+    const fetchChatData = async () => {
+      try {
+        if (chatId && typeof chatId === 'string') {
+          const response = await chatAPI.getChatInfo(chatId);
+          const chatInfo: Chat = response.data.chat;
+          setChatData(chatInfo);
+        }
+      } catch (error) {
+        console.error('Error fetching chat data:', error);
+      }
+    };
+
+    fetchChatData();
+  }, [chatId]);
+
   const [message, setMessage] = useState<string>('');
   const [messages, setMessages] = useState<Message[]>([]);
   const [showAlert, setShowAlert] = useState(false);
@@ -143,7 +161,13 @@ export default function Chat() {
 
   return (
     <>
-      <ChatroomHeader name={name} chatId={chatId} />
+      {chatData ? (
+        <ChatroomHeader
+          name={chatData.name}
+          chatId={chatData.id}
+          users={chatData.users}
+        />
+      ) : null}
       <div className={styles2.container}>
         <div className={styles2.container}>
           <div>


### PR DESCRIPTION
## 페이지


## ✨ 작업 내용
![image](https://github.com/Toy2-team10/Talkhaja/assets/122848687/0130e2e6-d06a-4aff-94b8-e4025e6eb80e)
짠

인원수가 일정 이상 늘어나게 되면 스크롤 바를 통해서 참여인원을 조회할 수 있도록 했습니다.

추가로 채팅방 이름에 적용한 것과 같이, 유저의 이름이 너무 길면 `...`으로 처리되도록 했습니다. 

## ❗️ 참고 사항
현재 말 그대로 기능 구현만 완료된 상태이고, 아직 손볼부분이 많습니다..!

### 1. 실시간으로 적용될 수 있도록 코드 변경 필요
(출,입 데이터를 관리할 useState를 만들어서 한번에 관리하도록 하겠습니다..!)

### 2. 출입 유저의 id가 아닌 이름으로 출입 메세지 표시하기
(현재 API는 완성하였고, 페이지에 적용해보도록 하겠습니다)

## 📸 스크린샷(선택)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
