### PR TITLE
Talk 11  feat/chat list/chat time 오픈채팅방 시간 표시 변경

### DIFF
--- a/pages/chat-list/ChatList.module.scss
+++ b/pages/chat-list/ChatList.module.scss
@@ -74,7 +74,7 @@
   @include time-diff($blue);
 }
 .time-hours-after {
-  @include time-diff($gray);
+  @include time-diff(#c3adde);
 }
 .time-days {
   @include time-diff($gray);

--- a/utils/timeFormat.ts
+++ b/utils/timeFormat.ts
@@ -9,34 +9,31 @@ export default function formatTime(updatedAt: Date | string): TimeFormatResult {
   const timeDiffInSeconds = (now.getTime() - messageTime.getTime()) / 1000;
 
   if (timeDiffInSeconds < 300) {
+    // 5분
     return { timeDiffText: '방금', className: 'time-now' };
   }
 
-  if (timeDiffInSeconds < 1800) {
-    // 30 minutes
-    const minutesAgo = Math.floor(timeDiffInSeconds / 60);
-    return { timeDiffText: `${minutesAgo}분 전`, className: 'time-now' };
-  }
-
   if (timeDiffInSeconds < 3600) {
-    return { timeDiffText: '30분', className: 'time-minutes' };
+    // 1시간 미만
+    const minutesAgo = Math.floor(timeDiffInSeconds / 60);
+    return { timeDiffText: `${minutesAgo} 분 전`, className: 'time-minutes' };
   }
 
   if (timeDiffInSeconds < 14400) {
-    // 4시간 이내
+    // 4시간 미만
     const hoursAgo = Math.floor(timeDiffInSeconds / 3600);
-    return { timeDiffText: `${hoursAgo}시간 전`, className: 'time-hours' };
+    return { timeDiffText: `${hoursAgo} 시간 전`, className: 'time-hours' };
   }
 
   if (timeDiffInSeconds < 86400) {
-    // 1일 이내 3시간 이후
+    // 1일 미만
     const hoursAgo = Math.floor(timeDiffInSeconds / 3600);
     return {
-      timeDiffText: `${hoursAgo}시간 전`,
+      timeDiffText: `${hoursAgo} 시간 전`,
       className: 'time-hours-after',
     };
   }
 
   const days = Math.floor(timeDiffInSeconds / 86400);
-  return { timeDiffText: `${days}일 전`, className: 'time-days' };
+  return { timeDiffText: `${days} 일 전`, className: 'time-days' };
 }


### PR DESCRIPTION
## 페이지
전체 채팅 목록 페이지
## ✨ 작업 내용
- 기존 30분~1시간 이내 : 30분이라고 표시 되었던 시간 n분 단위로 표시되도록 변경

## ❗️ 참고 사항
- 5분 미만: '방금'
- 1시간 미만 : n분 전
- 1일 미만 : n시간 전  
  - (1-3시간 전 / 4시간-23시간 전) : 클래스명 분리(time-hours/time-hours-after)
- 24시간 이상 지난 메시지 : n일 전



